### PR TITLE
Handle duplicate reservation conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ coverage==6.5.0
 Flask==2.2.2
 Flask-SQLAlchemy==2.5.1
 flask-swagger==0.2.14
-greenlet==2.0.1
+greenlet==3.0.3
 iniconfig==1.1.1
 itsdangerous==2.1.2
 Jinja2==3.1.2

--- a/src/aeroalpes/api/vuelos.py
+++ b/src/aeroalpes/api/vuelos.py
@@ -23,7 +23,8 @@ def reservar():
 
         return map_reserva.dto_a_externo(dto_final)
     except ExcepcionDominio as e:
-        return Response(json.dumps(dict(error=str(e))), status=400, mimetype='application/json')
+        status = 409 if "ya existe" in str(e) else 400
+        return Response(json.dumps(dict(error=str(e))), status=status, mimetype='application/json')
 
 @bp.route('/reserva', methods=('GET',))
 @bp.route('/reserva/<id>', methods=('GET',))

--- a/src/aeroalpes/modulos/vuelos/infraestructura/repositorios.py
+++ b/src/aeroalpes/modulos/vuelos/infraestructura/repositorios.py
@@ -6,7 +6,12 @@ persistir objetos dominio (agregaciones) en la capa de infraestructura del domin
 """
 
 from aeroalpes.config.db import db
-from aeroalpes.modulos.vuelos.dominio.repositorios import RepositorioReservas, RepositorioProveedores
+from aeroalpes.modulos.vuelos.dominio.repositorios import (
+    RepositorioReservas,
+    RepositorioProveedores,
+)
+from aeroalpes.seedwork.dominio.excepciones import ExcepcionDominio
+from sqlalchemy.exc import IntegrityError
 from aeroalpes.modulos.vuelos.dominio.objetos_valor import NombreAero, Odo, Leg, Segmento, Itinerario, CodigoIATA
 from aeroalpes.modulos.vuelos.dominio.entidades import Proveedor, Aeropuerto, Reserva
 from aeroalpes.modulos.vuelos.dominio.fabricas import FabricaVuelos
@@ -64,7 +69,11 @@ class RepositorioReservasSQLite(RepositorioReservas):
     def agregar(self, reserva: Reserva):
         reserva_dto = self.fabrica_vuelos.crear_objeto(reserva, MapeadorReserva())
         db.session.add(reserva_dto)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            raise ExcepcionDominio("La reserva ya existe")
 
     def actualizar(self, reserva: Reserva):
         # TODO

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -122,4 +122,4 @@ def test_reservar_vuelo(client):
 def test_reservar_vuelo_error_informacion_duplicada(client):
     rv = client.post('/vuelos/reserva', data=json.dumps(reserva_correcta()), content_type='application/json')
     assert rv is not None
-    assert rv.status_code == 500
+    assert rv.status_code == 409


### PR DESCRIPTION
## Summary
- catch IntegrityError on reservation commit
- return HTTP 409 for duplicate reservation
- expect 409 in API test
- update dependency greenlet for Python 3.12 compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706c129e50832caa6bd366695b8a37